### PR TITLE
Add clicks to force field verification

### DIFF
--- a/script.js
+++ b/script.js
@@ -20,10 +20,15 @@ function doTheMagic() {
         userRegistration.querySelector('#documentID').remove();
     }
     userRegistration.querySelector('#phone').value = phone;
+    userRegistration.querySelector('#phone').click();
     userRegistration.querySelector('#name').value = name;
+    userRegistration.querySelector('#name').click();
     userRegistration.querySelector('#surname').value = surname;
+    userRegistration.querySelector('#surname').click();
     userRegistration.querySelector('#surname2').value = surname2;
+    userRegistration.querySelector('#surname2').click();
     userRegistration.querySelector('#mail').value = mail;
+    userRegistration.querySelector('#mail').click();
     userRegistration.querySelector('#accept-btn').click();
 }
 doTheMagic();


### PR DESCRIPTION
Currently, after filling all forms in Firefox there are many problems with front-end verification of them.

This dirty fix clicks to all fields for initiating verification again after filling, which makes the process go smooth.